### PR TITLE
Indexer: Update to be comptible with movement's Aptos-core

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.78"
+components = [ "rustfmt", "rust-src", "clippy" ]
+profile = "minimal"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "aptos-profiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=074c4bac6cab49c0e6deaff99ce8d2814ab6e812#074c4bac6cab49c0e6deaff99ce8d2814ab6e812"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=074c4bac6cab49c0e6deaff99ce8d2814ab6e812#074c4bac6cab49c0e6deaff99ce8d2814ab6e812"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -173,7 +173,7 @@ dependencies = [
 [[package]]
 name = "aptos-system-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=074c4bac6cab49c0e6deaff99ce8d2814ab6e812#074c4bac6cab49c0e6deaff99ce8d2814ab6e812"
 dependencies = [
  "anyhow",
  "aptos-profiler",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "aptos-profiler"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=4541add3fd29826ec57f22658ca286d2d6134b93#4541add3fd29826ec57f22658ca286d2d6134b93"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -160,8 +160,8 @@ dependencies = [
 
 [[package]]
 name = "aptos-protos"
-version = "1.3.1"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb#5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb"
+version = "1.3.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -173,7 +173,7 @@ dependencies = [
 [[package]]
 name = "aptos-system-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=4541add3fd29826ec57f22658ca286d2d6134b93#4541add3fd29826ec57f22658ca286d2d6134b93"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-profiler",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 homepage = "https://aptoslabs.com"
 license = "Apache-2.0"
 publish = false
-repository = "https://github.com/aptos-labs/aptos-indexer-processors"
+repository = "https://github.com/movementlabsxyz/aptos-indexer-processors"
 rust-version = "1.75"
 
 [workspace.dependencies]
@@ -19,8 +19,9 @@ aptos-moving-average = { path = "moving-average" }
 
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.62"
-aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb" }
-aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "4541add3fd29826ec57f22658ca286d2d6134b93" }
+# Aptos repos must have the same rev has the Suzuka node it connect to.
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "074c4bac6cab49c0e6deaff99ce8d2814ab6e812" }
+aptos-system-utils = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "074c4bac6cab49c0e6deaff99ce8d2814ab6e812" }
 async-trait = "0.1.53"
 backtrace = "0.3.58"
 base64 = "0.13.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,8 +20,8 @@ aptos-moving-average = { path = "moving-average" }
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.62"
 # Aptos repos must have the same rev has the Suzuka node it connect to.
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "51d875c93565e11f4e3f8321d200b406ed55a28" }
-aptos-system-utils = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "51d875c93565e11f4e3f8321d200b406ed55a28" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "338f9a1bcc06f62ce4a4994f1642b9a61b631ee0" }
+aptos-system-utils = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "338f9a1bcc06f62ce4a4994f1642b9a61b631ee0" }
 async-trait = "0.1.53"
 backtrace = "0.3.58"
 base64 = "0.13.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,8 +20,8 @@ aptos-moving-average = { path = "moving-average" }
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.62"
 # Aptos repos must have the same rev has the Suzuka node it connect to.
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "074c4bac6cab49c0e6deaff99ce8d2814ab6e812" }
-aptos-system-utils = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "074c4bac6cab49c0e6deaff99ce8d2814ab6e812" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "51d875c93565e11f4e3f8321d200b406ed55a28" }
+aptos-system-utils = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "51d875c93565e11f4e3f8321d200b406ed55a28" }
 async-trait = "0.1.53"
 backtrace = "0.3.58"
 base64 = "0.13.0"

--- a/rust/processor/src/db/common/models/account_transaction_models/account_transactions.rs
+++ b/rust/processor/src/db/common/models/account_transaction_models/account_transactions.rs
@@ -71,17 +71,20 @@ impl AccountTransaction {
             ),
             TxnData::Genesis(inner) => (&inner.events, vec![]),
             TxnData::BlockMetadata(inner) => (&inner.events, vec![]),
-            TxnData::Validator(inner) => (&inner.events, vec![]),
+            TxnData::Validator(_inner) => (&Vec::new(), vec![]),
             _ => {
                 return AHashMap::new();
             },
         };
         let mut account_transactions = AHashMap::new();
         for sig in &signatures {
-            account_transactions.insert((sig.signer.clone(), txn_version), Self {
-                transaction_version: txn_version,
-                account_address: sig.signer.clone(),
-            });
+            account_transactions.insert(
+                (sig.signer.clone(), txn_version),
+                Self {
+                    transaction_version: txn_version,
+                    account_address: sig.signer.clone(),
+                },
+            );
         }
         for event in events {
             account_transactions.extend(Self::from_event(event, txn_version));
@@ -107,10 +110,13 @@ impl AccountTransaction {
     fn from_event(event: &Event, txn_version: i64) -> AHashMap<AccountTransactionPK, Self> {
         let account_address =
             standardize_address(event.key.as_ref().unwrap().account_address.as_str());
-        AHashMap::from([((account_address.clone(), txn_version), Self {
-            transaction_version: txn_version,
-            account_address,
-        })])
+        AHashMap::from([(
+            (account_address.clone(), txn_version),
+            Self {
+                transaction_version: txn_version,
+                account_address,
+            },
+        )])
     }
 
     /// Base case, record resource account. If the resource is an object, then we record the owner as well
@@ -121,16 +127,22 @@ impl AccountTransaction {
     ) -> anyhow::Result<AHashMap<AccountTransactionPK, Self>> {
         let mut result = AHashMap::new();
         let account_address = standardize_address(write_resource.address.as_str());
-        result.insert((account_address.clone(), txn_version), Self {
-            transaction_version: txn_version,
-            account_address,
-        });
+        result.insert(
+            (account_address.clone(), txn_version),
+            Self {
+                transaction_version: txn_version,
+                account_address,
+            },
+        );
         if let Some(inner) = &ObjectWithMetadata::from_write_resource(write_resource, txn_version)?
         {
-            result.insert((inner.object_core.get_owner_address(), txn_version), Self {
-                transaction_version: txn_version,
-                account_address: inner.object_core.get_owner_address(),
-            });
+            result.insert(
+                (inner.object_core.get_owner_address(), txn_version),
+                Self {
+                    transaction_version: txn_version,
+                    account_address: inner.object_core.get_owner_address(),
+                },
+            );
         }
         Ok(result)
     }
@@ -145,10 +157,13 @@ impl AccountTransaction {
     ) -> anyhow::Result<AHashMap<AccountTransactionPK, Self>> {
         let mut result = AHashMap::new();
         let account_address = standardize_address(delete_resource.address.as_str());
-        result.insert((account_address.clone(), txn_version), Self {
-            transaction_version: txn_version,
-            account_address,
-        });
+        result.insert(
+            (account_address.clone(), txn_version),
+            Self {
+                transaction_version: txn_version,
+                account_address,
+            },
+        );
         Ok(result)
     }
 }

--- a/rust/processor/src/db/common/models/account_transaction_models/account_transactions.rs
+++ b/rust/processor/src/db/common/models/account_transaction_models/account_transactions.rs
@@ -58,6 +58,8 @@ impl AccountTransaction {
             panic!("Transaction info doesn't exist for version {}", txn_version)
         });
         let wscs = &transaction_info.changes;
+        // Can be removed with rustc version 1.80+ and replace with &Vec::new()
+        let default = Vec::new();
         let (events, signatures) = match txn_data {
             TxnData::User(inner) => (
                 &inner.events,
@@ -71,7 +73,8 @@ impl AccountTransaction {
             ),
             TxnData::Genesis(inner) => (&inner.events, vec![]),
             TxnData::BlockMetadata(inner) => (&inner.events, vec![]),
-            TxnData::Validator(_inner) => (&Vec::new(), vec![]),
+            // No events in Movement protobuf Validator Tx.
+            TxnData::Validator(_inner) => (&default, vec![]),
             _ => {
                 return AHashMap::new();
             },

--- a/rust/processor/src/db/common/models/default_models/move_tables.rs
+++ b/rust/processor/src/db/common/models/default_models/move_tables.rs
@@ -66,11 +66,19 @@ impl TableItem {
                 key: write_table_item.key.to_string(),
                 table_handle: standardize_address(&write_table_item.handle.to_string()),
                 decoded_key: serde_json::from_str(
-                    write_table_item.data.as_ref().unwrap().key.as_str(),
+                    write_table_item
+                        .data
+                        .as_ref()
+                        .map(|data| data.key.as_str())
+                        .unwrap_or("{}"),
                 )
                 .unwrap(),
                 decoded_value: serde_json::from_str(
-                    write_table_item.data.as_ref().unwrap().value.as_str(),
+                    write_table_item
+                        .data
+                        .as_ref()
+                        .map(|data| data.value.as_str())
+                        .unwrap_or("{}"),
                 )
                 .unwrap(),
                 is_deleted: false,
@@ -80,11 +88,19 @@ impl TableItem {
                 key_hash: hash_str(&write_table_item.key.to_string()),
                 key: write_table_item.key.to_string(),
                 decoded_key: serde_json::from_str(
-                    write_table_item.data.as_ref().unwrap().key.as_str(),
+                    write_table_item
+                        .data
+                        .as_ref()
+                        .map(|data| data.key.as_str())
+                        .unwrap_or("{}"),
                 )
                 .unwrap(),
                 decoded_value: serde_json::from_str(
-                    write_table_item.data.as_ref().unwrap().value.as_str(),
+                    write_table_item
+                        .data
+                        .as_ref()
+                        .map(|data| data.value.as_str())
+                        .unwrap_or("{}"),
                 )
                 .unwrap(),
                 last_transaction_version: transaction_version,
@@ -107,7 +123,11 @@ impl TableItem {
                 key: delete_table_item.key.to_string(),
                 table_handle: standardize_address(&delete_table_item.handle.to_string()),
                 decoded_key: serde_json::from_str(
-                    delete_table_item.data.as_ref().unwrap().key.as_str(),
+                    delete_table_item
+                        .data
+                        .as_ref()
+                        .map(|data| data.key.as_str())
+                        .unwrap_or("{}"),
                 )
                 .unwrap(),
 
@@ -119,7 +139,11 @@ impl TableItem {
                 key_hash: hash_str(&delete_table_item.key.to_string()),
                 key: delete_table_item.key.to_string(),
                 decoded_key: serde_json::from_str(
-                    delete_table_item.data.as_ref().unwrap().key.as_str(),
+                    delete_table_item
+                        .data
+                        .as_ref()
+                        .map(|data| data.key.as_str())
+                        .unwrap_or("{}"),
                 )
                 .unwrap(),
                 decoded_value: None,
@@ -134,8 +158,16 @@ impl TableMetadata {
     pub fn from_write_table_item(table_item: &WriteTableItem) -> Self {
         Self {
             handle: table_item.handle.to_string(),
-            key_type: table_item.data.as_ref().unwrap().key_type.clone(),
-            value_type: table_item.data.as_ref().unwrap().value_type.clone(),
+            key_type: table_item
+                .data
+                .as_ref()
+                .map(|data| data.key_type.clone())
+                .unwrap_or(String::new()),
+            value_type: table_item
+                .data
+                .as_ref()
+                .map(|data| data.value_type.clone())
+                .unwrap_or(String::new()),
         }
     }
 }

--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -314,7 +314,7 @@ impl Transaction {
                 vec![],
                 vec![],
             ),
-            TxnData::Validator(inner) => {
+            TxnData::Validator(_inner) => {
                 let (wsc, wsc_detail) = WriteSetChangeModel::from_write_set_changes(
                     &transaction_info.changes,
                     txn_version,
@@ -328,7 +328,8 @@ impl Transaction {
                         None,
                         txn_version,
                         transaction_type,
-                        inner.events.len() as i64,
+                        // No events in Movement protobuf Validator Tx.
+                        0,
                         block_height,
                         epoch,
                         block_timestamp,

--- a/rust/processor/src/db/common/models/stake_models/delegator_activities.rs
+++ b/rust/processor/src/db/common/models/stake_models/delegator_activities.rs
@@ -50,7 +50,8 @@ impl DelegatedStakingActivity {
         let events = match txn_data {
             TxnData::User(txn) => &txn.events,
             TxnData::BlockMetadata(txn) => &txn.events,
-            TxnData::Validator(txn) => &txn.events,
+            // No events in Movement protobuf Validator Tx.
+            TxnData::Validator(_txn) => &Vec::new(),
             _ => return Ok(delegator_activities),
         };
         for (index, event) in events.iter().enumerate() {

--- a/rust/processor/src/db/common/models/stake_models/delegator_activities.rs
+++ b/rust/processor/src/db/common/models/stake_models/delegator_activities.rs
@@ -47,11 +47,14 @@ impl DelegatedStakingActivity {
         };
 
         let txn_version = transaction.version as i64;
+        // Can be removed with rustc version 1.80+ and replace with &Vec::new()
+        let default = Vec::new();
+
         let events = match txn_data {
             TxnData::User(txn) => &txn.events,
             TxnData::BlockMetadata(txn) => &txn.events,
             // No events in Movement protobuf Validator Tx.
-            TxnData::Validator(_txn) => &Vec::new(),
+            TxnData::Validator(_txn) => &default,
             _ => return Ok(delegator_activities),
         };
         for (index, event) in events.iter().enumerate() {

--- a/rust/processor/src/processors/default_processor.rs
+++ b/rust/processor/src/processors/default_processor.rs
@@ -27,7 +27,6 @@ use diesel::{
 };
 use std::fmt::Debug;
 use tokio::join;
-use tracing::error;
 
 pub struct DefaultProcessor {
     connection_pool: ArcDbPool,
@@ -168,7 +167,6 @@ fn insert_transactions_query(
     Option<&'static str>,
 ) {
     use schema::transactions::dsl::*;
-
     (
         diesel::insert_into(schema::transactions::table)
             .values(items_to_insert)
@@ -367,7 +365,7 @@ impl ProcessorTrait for DefaultProcessor {
                 },
             )),
             Err(e) => {
-                error!(
+                tracing::warn!(
                     start_version = start_version,
                     end_version = end_version,
                     processor_name = self.name(),

--- a/rust/processor/src/processors/events_processor.rs
+++ b/rust/processor/src/processors/events_processor.rs
@@ -131,7 +131,7 @@ impl ProcessorTrait for EventsProcessor {
                 TxnData::Genesis(tx_inner) => &tx_inner.events,
                 TxnData::User(tx_inner) => &tx_inner.events,
                 // No events in Movement protobuf Validator Tx.
-                TxnData::Validator(_tx_inner) => &Vec::new(),
+                TxnData::Validator(_tx_inner) => &default,
                 _ => &default,
             };
 

--- a/rust/processor/src/processors/events_processor.rs
+++ b/rust/processor/src/processors/events_processor.rs
@@ -130,7 +130,8 @@ impl ProcessorTrait for EventsProcessor {
                 TxnData::BlockMetadata(tx_inner) => &tx_inner.events,
                 TxnData::Genesis(tx_inner) => &tx_inner.events,
                 TxnData::User(tx_inner) => &tx_inner.events,
-                TxnData::Validator(tx_inner) => &tx_inner.events,
+                // No events in Movement protobuf Validator Tx.
+                TxnData::Validator(_tx_inner) => &Vec::new(),
                 _ => &default,
             };
 

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -482,7 +482,8 @@ async fn parse_v2_coin(
         let default = vec![];
         let (events, user_request, entry_function_id_str) = match txn_data {
             TxnData::BlockMetadata(tx_inner) => (&tx_inner.events, None, None),
-            TxnData::Validator(tx_inner) => (&tx_inner.events, None, None),
+            // No events in Movement protobuf Validator Tx.
+            TxnData::Validator(_tx_inner) => (&Vec::new(), None, None),
             TxnData::Genesis(tx_inner) => (&tx_inner.events, None, None),
             TxnData::User(tx_inner) => {
                 let user_request = tx_inner

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -483,7 +483,7 @@ async fn parse_v2_coin(
         let (events, user_request, entry_function_id_str) = match txn_data {
             TxnData::BlockMetadata(tx_inner) => (&tx_inner.events, None, None),
             // No events in Movement protobuf Validator Tx.
-            TxnData::Validator(_tx_inner) => (&Vec::new(), None, None),
+            TxnData::Validator(_tx_inner) => (&default, None, None),
             TxnData::Genesis(tx_inner) => (&tx_inner.events, None, None),
             TxnData::User(tx_inner) => {
                 let user_request = tx_inner


### PR DESCRIPTION
Use the movement's Aptos-core crate to be compatible with protobuff version
Remove events that deosn't exist in movement's Aptos-core.
Remove unwrap in WriteSet that are not present in Movement Tx.

To Test/Run/Compile
Under the rust folder, run: `cargo run --release -p processor -- -c config.yaml`