### PR TITLE
Musitdev/correct chain id init

### DIFF
--- a/rust/processor/src/grpc_stream.rs
+++ b/rust/processor/src/grpc_stream.rs
@@ -239,6 +239,7 @@ pub async fn get_chain_id(
     indexer_grpc_reconnection_timeout_secs: Duration,
     auth_token: String,
     processor_name: String,
+    starting_version_from_db: u64,
 ) -> u64 {
     info!(
         processor_name = processor_name,
@@ -251,8 +252,8 @@ pub async fn get_chain_id(
         indexer_grpc_http2_ping_interval,
         indexer_grpc_http2_ping_timeout,
         indexer_grpc_reconnection_timeout_secs,
-        1,
-        Some(2),
+        starting_version_from_db,
+        Some(starting_version_from_db + 1),
         auth_token.clone(),
         processor_name.to_string(),
     )

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -257,6 +257,7 @@ impl Worker {
             self.grpc_http2_config.grpc_connection_timeout_secs(),
             self.auth_token.clone(),
             processor_name.to_string(),
+            starting_version_from_db,
         )
         .await;
         self.check_or_update_chain_id(chain_id as i64)


### PR DESCRIPTION
To get the chain id, the indexer sends a gRpc request for Tx 1 and 2 and extract the chain id from them.
The issue is if the node has a pruned db it don't have the Tx 1 and 2 so the Grpc call fail and the indexer panic.
This PR correct it by using the last sync version in db to request the Tx needed to get the chain_id.