### PR TITLE
fix: correct movement name service module

### DIFF
--- a/rust/processor/src/db/common/models/ans_models/ans_utils.rs
+++ b/rust/processor/src/db/common/models/ans_models/ans_utils.rs
@@ -214,10 +214,10 @@ impl AnsWriteResource {
         let data = write_resource.data.as_str();
 
         match type_str.clone() {
-            x if x == format!("{}::v2_1_domains::NameRecord", ans_v2_contract_address) => {
+            x if x == format!("{}::domains::NameRecord", ans_v2_contract_address) => {
                 serde_json::from_str(data).map(|inner| Some(Self::NameRecordV2(inner)))
             },
-            x if x == format!("{}::v2_1_domains::SubdomainExt", ans_v2_contract_address) => {
+            x if x == format!("{}::domains::SubdomainExt", ans_v2_contract_address) => {
                 serde_json::from_str(data).map(|inner| Some(Self::SubdomainExtV2(inner)))
             },
             _ => Ok(None),
@@ -324,10 +324,10 @@ impl V2AnsEvent {
     pub fn is_event_supported(event_type: &str, ans_v2_contract_address: &str) -> bool {
         [
             format!(
-                "{}::v2_1_domains::SetReverseLookupEvent",
+                "{}::domains::SetReverseLookupEvent",
                 ans_v2_contract_address
             ),
-            format!("{}::v2_1_domains::RenewNameEvent", ans_v2_contract_address),
+            format!("{}::domains::RenewNameEvent", ans_v2_contract_address),
         ]
         .contains(&event_type.to_string())
     }
@@ -347,13 +347,13 @@ impl V2AnsEvent {
         match type_str.clone() {
             x if x
                 == format!(
-                    "{}::v2_1_domains::SetReverseLookupEvent",
+                    "{}::domains::SetReverseLookupEvent",
                     ans_v2_contract_address
                 ) =>
             {
                 serde_json::from_str(data).map(|inner| Some(Self::SetReverseLookupEvent(inner)))
             },
-            x if x == format!("{}::v2_1_domains::RenewNameEvent", ans_v2_contract_address) => {
+            x if x == format!("{}::domains::RenewNameEvent", ans_v2_contract_address) => {
                 serde_json::from_str(data).map(|inner| Some(Self::RenewNameEvent(inner)))
             },
             _ => Ok(None),


### PR DESCRIPTION
# Why did we need it?
The current code is forked from Aptos, specifically from its Name Service version 2.1. However, the Movement Name Service is the first version. This update changes the namespace from v2_1_domains to domains to align with the Movement Name Service's initial version.

# What did we change?
- Correct the module name to interact with the deployed Movement Name Service contract.

# How Has This Been Tested?
- Movement Name Contract on porto testnet: 0x67bf15b3eed0fc62deea9630bbbd1d48842550655140f913699a1ca7e6f727d8

# Screenshots (if appropriate)
![telegram-cloud-photo-size-1-5037483768029491520-y](https://github.com/user-attachments/assets/e30acc48-1f90-44c1-b198-5783bac12b60)
![image](https://github.com/user-attachments/assets/187826bc-a828-4d7d-9d96-88e578030044)
![image](https://github.com/user-attachments/assets/1c9754c0-727d-4363-907f-b15a979bcab9)
