### PR TITLE
Update to Movement fork of bcs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -354,8 +354,9 @@ dependencies = [
 
 [[package]]
 name = "bcs"
-version = "0.1.4"
-source = "git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d#d31fab9d81748e2594be5cd5cdf845786a30562d"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
  "serde",
  "thiserror",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -355,8 +355,7 @@ dependencies = [
 [[package]]
 name = "bcs"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
+source = "git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c#bc16d2d39cabafaabd76173dd1b04b2aa170cf0c"
 dependencies = [
  "serde",
  "thiserror",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ async-trait = "0.1.53"
 backtrace = "0.3.58"
 base64 = "0.13.0"
 bb8 = "0.8.1"
-bcs = "0.1.6"
+bcs = { git = "https://github.com/movementlabsxyz/bcs.git", rev = "bc16d2d39cabafaabd76173dd1b04b2aa170cf0c" }
 bigdecimal = { version = "0.4.0", features = ["serde"] }
 bitflags = "2.5.0"
 chrono = { version = "0.4.19", features = ["clock", "serde"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ async-trait = "0.1.53"
 backtrace = "0.3.58"
 base64 = "0.13.0"
 bb8 = "0.8.1"
-bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
+bcs = "0.1.6"
 bigdecimal = { version = "0.4.0", features = ["serde"] }
 bitflags = "2.5.0"
 chrono = { version = "0.4.19", features = ["clock", "serde"] }


### PR DESCRIPTION
I don't know what has prevented Aptos Labs from doing this, but all changes in the aptos-core fork have been merged upstream.

However, we also need https://github.com/zefchain/bcs/pull/12, so we'll have to use the Movement fork for the time being.

This is needed for the Zstd bomb fix in https://github.com/movementlabsxyz/movement/issues/876.