### PR TITLE
fix: rename ns token name

### DIFF
--- a/rust/processor/src/db/common/models/ans_models/ans_utils.rs
+++ b/rust/processor/src/db/common/models/ans_models/ans_utils.rs
@@ -41,7 +41,7 @@ pub struct OptionalBigDecimal {
 pub fn get_token_name(domain_name: &str, subdomain_name: &str) -> String {
     let domain = truncate_str(domain_name, DOMAIN_LENGTH);
     let subdomain = truncate_str(subdomain_name, DOMAIN_LENGTH);
-    let mut token_name = format!("{}.apt", &domain);
+    let mut token_name = format!("{}.move", &domain);
     if !subdomain.is_empty() {
         token_name = format!("{}.{}", &subdomain, token_name);
     }


### PR DESCRIPTION
## What is changed?
- `token_name` is added to `current_ans_lookup_v2` with `.apt` suffix -> `.move` suffix

## Why we need that change?
- It's movement name service, so the suffix should be `.move`
- To make it compatible with other tables, such as `current_token_datas_v2`