### PR TITLE
Bug, remove most of the panic inside the processors.

### DIFF
--- a/rust/processor/src/db/common/models/coin_models/coin_activities.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_activities.rs
@@ -234,15 +234,10 @@ impl CoinActivity {
             addr: standardize_address(event.key.as_ref().unwrap().account_address.as_str()),
             creation_num: event.key.as_ref().unwrap().creation_number as i64,
         };
-        let coin_type =
-            event_to_coin_type
-                .get(&event_move_guid)
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Could not find event in resources (CoinStore), version: {}, event guid: {:?}, mapping: {:?}",
-                        txn_version, event_move_guid, event_to_coin_type
-                    )
-                }).clone();
+        let coin_type = event_to_coin_type
+            .get(&event_move_guid)
+            .cloned()
+            .unwrap_or_else(|| "0x1::coin::UnknownCoinType".to_string());
 
         Self {
             transaction_version: txn_version,

--- a/rust/processor/src/db/common/models/coin_models/coin_balances.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_balances.rs
@@ -54,7 +54,7 @@ impl CoinBalance {
                     &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     write_resource.type_str.as_ref(),
                     txn_version,
-                );
+                )?;
                 let owner_address = standardize_address(write_resource.address.as_str());
                 let coin_balance = Self {
                     transaction_version: txn_version,

--- a/rust/processor/src/db/common/models/coin_models/coin_infos.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_infos.rs
@@ -40,7 +40,7 @@ impl CoinInfo {
                     &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     write_resource.type_str.as_ref(),
                     txn_version,
-                );
+                )?;
                 let (supply_aggregator_table_handle, supply_aggregator_table_key) = inner
                     .get_aggregator_metadata()
                     .map(|agg| (Some(agg.handle), Some(agg.key)))

--- a/rust/processor/src/db/common/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/db/common/models/default_models/write_set_changes.rs
@@ -186,9 +186,7 @@ impl WriteSetChange {
             WriteSetChangeTypeEnum::WriteModule => "write_module".to_string(),
             WriteSetChangeTypeEnum::WriteResource => "write_resource".to_string(),
             WriteSetChangeTypeEnum::WriteTableItem => "write_table_item".to_string(),
-            WriteSetChangeTypeEnum::Unspecified => {
-                panic!("WriteSetChange type must be specified.")
-            },
+            WriteSetChangeTypeEnum::Unspecified => "unspecified_writeset".to_string(),
         }
     }
 }

--- a/rust/processor/src/db/common/models/fungible_asset_models/parquet_v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/parquet_v2_fungible_asset_balances.rs
@@ -134,7 +134,7 @@ impl FungibleAssetBalance {
                 &delete_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 delete_resource.type_str.as_ref(),
                 txn_version,
-            );
+            )?;
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(delete_resource.address.as_str());
                 let storage_id =
@@ -187,7 +187,7 @@ impl FungibleAssetBalance {
                 &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 write_resource.type_str.as_ref(),
                 txn_version,
-            );
+            )?;
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(write_resource.address.as_str());
                 let storage_id =

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -218,7 +218,7 @@ impl FungibleAssetBalance {
                 &delete_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 delete_resource.type_str.as_ref(),
                 txn_version,
-            );
+            )?;
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(delete_resource.address.as_str());
                 let storage_id =
@@ -271,7 +271,7 @@ impl FungibleAssetBalance {
                 &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 write_resource.type_str.as_ref(),
                 txn_version,
-            );
+            )?;
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(write_resource.address.as_str());
                 let storage_id =

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_utils.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_utils.rs
@@ -29,15 +29,15 @@ pub struct FeeStatement {
 impl FeeStatement {
     pub fn from_event(data_type: &str, data: &str, txn_version: i64) -> Option<Self> {
         if data_type == "0x1::transaction_fee::FeeStatement" {
-            let fee_statement: FeeStatement = serde_json::from_str(data).unwrap_or_else(|_| {
-                tracing::error!(
-                    transaction_version = txn_version,
-                    data = data,
-                    "failed to parse event for fee statement"
-                );
-                panic!();
-            });
-            Some(fee_statement)
+            serde_json::from_str(data)
+                .map_err(|_| {
+                    tracing::error!(
+                        transaction_version = txn_version,
+                        data = data,
+                        "failed to parse event for fee statement"
+                    );
+                })
+                .ok()
         } else {
             None
         }

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_metadata.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_metadata.rs
@@ -115,7 +115,7 @@ impl FungibleAssetMetadataModel {
                     &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     write_resource.type_str.as_ref(),
                     txn_version,
-                );
+                )?;
                 let (supply_aggregator_table_handle, supply_aggregator_table_key) = inner
                     .get_aggregator_metadata()
                     .map(|agg| (Some(agg.handle), Some(agg.key)))
@@ -158,7 +158,7 @@ impl FungibleAssetMetadataModel {
                     &delete_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     delete_resource.type_str.as_ref(),
                     txn_version,
-                );
+                )?;
                 let (supply_aggregator_table_handle, supply_aggregator_table_key) = inner
                     .get_aggregator_metadata()
                     .map(|agg| (Some(agg.handle), Some(agg.key)))

--- a/rust/processor/src/db/common/models/token_models/token_claims.rs
+++ b/rust/processor/src/db/common/models/token_models/token_claims.rs
@@ -156,13 +156,16 @@ impl CurrentTokenPendingClaim {
         if let Some(offer) = &maybe_offer {
             let table_handle = standardize_address(&table_item.handle.to_string());
 
-            let table_metadata = table_handle_to_owner.get(&table_handle).unwrap_or_else(|| {
-                panic!(
+            let table_metadata = table_handle_to_owner.get(&table_handle).ok_or_else(|| {
+                tracing::error!(
                     "Missing table handle metadata for claim. \
                     Version: {}, table handle for PendingClaims: {}, all metadata: {:?}",
-                    txn_version, table_handle, table_handle_to_owner
-                )
-            });
+                    txn_version,
+                    table_handle,
+                    table_handle_to_owner
+                );
+                anyhow::anyhow!("Missing table handle metadata for claim")
+            })?;
 
             let token_id = offer.token_id.clone();
             let token_data_id_struct = token_id.token_data_id;

--- a/rust/processor/src/db/common/models/user_transactions_models/signatures.rs
+++ b/rust/processor/src/db/common/models/user_transactions_models/signatures.rs
@@ -120,13 +120,13 @@ impl Signature {
         t: &TransactionSignaturePb,
         transaction_version: i64,
     ) -> Option<String> {
-        let sig = t.signature.as_ref().unwrap_or_else(|| {
+        let sig = t.signature.as_ref().or_else(|| {
             tracing::error!(
                 transaction_version = transaction_version,
                 "Transaction signature is missing"
             );
-            panic!("Transaction signature is missing");
-        });
+            None
+        })?;
         match sig {
             SignatureEnum::FeePayer(sig) => Some(standardize_address(&sig.fee_payer_address)),
             _ => None,

--- a/rust/processor/src/grpc_stream.rs
+++ b/rust/processor/src/grpc_stream.rs
@@ -439,7 +439,7 @@ pub async fn create_fetcher_loop(
                                 current_fetched_version = start_version,
                                 "[Parser] Received batch with gap from GRPC stream"
                             );
-                            panic!("[Parser] Received batch with gap from GRPC stream");
+                            return;
                         }
                         last_fetched_version = end_version as i64;
 
@@ -486,7 +486,7 @@ pub async fn create_fetcher_loop(
                                         error = ?e,
                                         "[Parser] Error sending GRPC response to channel."
                                     );
-                                    panic!("[Parser] Error sending GRPC response to channel.")
+                                    return;
                                 },
                             }
                         } else {
@@ -523,7 +523,7 @@ pub async fn create_fetcher_loop(
                                             error = ?e,
                                             "[Parser] Error sending GRPC response to channel."
                                         );
-                                        panic!("[Parser] Error sending GRPC response to channel.")
+                                        return;
                                     },
                                 }
                             }
@@ -661,7 +661,7 @@ pub async fn create_fetcher_loop(
                     stream_address = indexer_grpc_data_service_address.to_string(),
                     "[Parser] Reconnected more than {RECONNECTION_MAX_RETRIES} times. Will not retry.",
                 );
-                panic!("[Parser] Reconnected more than {RECONNECTION_MAX_RETRIES} times. Will not retry.")
+                return;
             }
             reconnection_retries += 1;
             info!(

--- a/rust/processor/src/processors/ans_processor.rs
+++ b/rust/processor/src/processors/ans_processor.rs
@@ -588,13 +588,17 @@ fn parse_ans(
                                 txn_version,
                                 wsc_index as i64,
                             )
-                            .unwrap_or_else(|e| {
+                            .map_err(|e| {
                                 error!(
                                     error = ?e,
                                     "Error parsing ANS v1 name record from write table item"
                                 );
-                                panic!();
+                                anyhow::anyhow!(
+                                    "Error parsing ANS v1 name record from write table item"
+                                )
                             })
+                            .ok()
+                            .flatten()
                         {
                             all_current_ans_lookups
                                 .insert(current_ans_lookup.pk(), current_ans_lookup.clone());
@@ -614,13 +618,17 @@ fn parse_ans(
                                 txn_version,
                                 wsc_index as i64,
                             )
-                                .unwrap_or_else(|e| {
-                                    error!(
-                                error = ?e,
-                                "Error parsing ANS v1 primary name from write table item"
-                            );
-                                    panic!();
-                                })
+                            .map_err(|e| {
+                                error!(
+                                    error = ?e,
+                                    "Error parsing ANS v1 primary name from write table item"
+                                );
+                                anyhow::anyhow!(
+                                    "Error parsing ANS v1 primary name from write table item"
+                                )
+                            })
+                            .ok()
+                            .flatten()
                         {
                             all_current_ans_primary_names
                                 .insert(current_primary_name.pk(), current_primary_name.clone());
@@ -642,13 +650,17 @@ fn parse_ans(
                                 txn_version,
                                 wsc_index as i64,
                             )
-                            .unwrap_or_else(|e| {
+                            .map_err(|e| {
                                 error!(
                                     error = ?e,
                                     "Error parsing ANS v1 name record from delete table item"
                                 );
-                                panic!();
+                                anyhow::anyhow!(
+                                    "Error parsing ANS v1 name record from delete table item"
+                                )
                             })
+                            .ok()
+                            .flatten()
                         {
                             all_current_ans_lookups
                                 .insert(current_ans_lookup.pk(), current_ans_lookup.clone());
@@ -668,13 +680,17 @@ fn parse_ans(
                                 txn_version,
                                 wsc_index as i64,
                             )
-                                .unwrap_or_else(|e| {
-                                    error!(
-                                error = ?e,
-                                "Error parsing ANS v1 primary name from delete table item"
-                            );
-                                    panic!();
-                                })
+                            .map_err(|e| {
+                                error!(
+                                    error = ?e,
+                                    "Error parsing ANS v1 primary name from delete table item"
+                                );
+                                anyhow::anyhow!(
+                                    "Error parsing ANS v1 primary name from delete table item"
+                                )
+                            })
+                            .ok()
+                            .flatten()
                         {
                             all_current_ans_primary_names
                                 .insert(current_primary_name.pk(), current_primary_name.clone());
@@ -697,13 +713,17 @@ fn parse_ans(
                                 wsc_index as i64,
                                 &v2_address_to_subdomain_ext,
                             )
-                            .unwrap_or_else(|e| {
+                            .map_err(|e| {
                                 error!(
                                     error = ?e,
                                     "Error parsing ANS v2 name record from write resource"
                                 );
-                                panic!();
+                                anyhow::anyhow!(
+                                    "Error parsing ANS v2 name record from write resource"
+                                )
                             })
+                            .ok()
+                            .flatten()
                         {
                             all_current_ans_lookups_v2
                                 .insert(current_ans_lookup_v2.pk(), current_ans_lookup_v2);

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -638,14 +638,17 @@ async fn parse_v2_coin(
                 &event_to_v1_coin_type,
                 index as i64,
             )
-            .unwrap_or_else(|e| {
+            .map_err(|e| {
                 tracing::error!(
                     transaction_version = txn_version,
                     index = index,
                     error = ?e,
                     "[Parser] error parsing fungible asset activity v1");
-                panic!("[Parser] error parsing fungible asset activity v1");
-            }) {
+                anyhow::anyhow!("[Parser] error parsing fungible asset activity v1")
+            })
+            .ok()
+            .flatten()
+            {
                 fungible_asset_activities.push(v1_activity);
             }
             if let Some(v2_activity) = FungibleAssetActivity::get_v2_from_event(
@@ -658,14 +661,17 @@ async fn parse_v2_coin(
                 &fungible_asset_object_helper,
             )
             .await
-            .unwrap_or_else(|e| {
+            .map_err(|e| {
                 tracing::error!(
                     transaction_version = txn_version,
                     index = index,
                     error = ?e,
                     "[Parser] error parsing fungible asset activity v2");
-                panic!("[Parser] error parsing fungible asset activity v2");
-            }) {
+                anyhow::anyhow!("[Parser] error parsing fungible asset activity v2")
+            })
+            .ok()
+            .flatten()
+            {
                 fungible_asset_activities.push(v2_activity);
             }
         }
@@ -685,14 +691,16 @@ async fn parse_v2_coin(
                             txn_version,
                             txn_timestamp,
                         )
-                        .unwrap_or_else(|e| {
+                        .map_err(|e| {
                             tracing::error!(
                             transaction_version = txn_version,
                             index = index,
                                 error = ?e,
                             "[Parser] error parsing fungible metadata v1");
-                            panic!("[Parser] error parsing fungible metadata v1");
+                            anyhow::anyhow!("[Parser] error parsing fungible metadata v1")
                         })
+                        .ok()
+                        .flatten()
                     {
                         fungible_asset_metadata.insert(fa_metadata.asset_type.clone(), fa_metadata);
                     }
@@ -703,14 +711,16 @@ async fn parse_v2_coin(
                             txn_timestamp,
                             &fungible_asset_object_helper,
                         )
-                        .unwrap_or_else(|e| {
+                        .map_err(|e| {
                             tracing::error!(
                             transaction_version = txn_version,
                             index = index,
                                 error = ?e,
                             "[Parser] error parsing fungible metadata v2");
-                            panic!("[Parser] error parsing fungible metadata v2");
+                            anyhow::anyhow!("[Parser] error parsing fungible metadata v2")
                         })
+                        .ok()
+                        .flatten()
                     {
                         fungible_asset_metadata.insert(fa_metadata.asset_type.clone(), fa_metadata);
                     }
@@ -723,14 +733,16 @@ async fn parse_v2_coin(
                             &fungible_asset_object_helper,
                         )
                         .await
-                        .unwrap_or_else(|e| {
+                        .map_err(|e| {
                             tracing::error!(
                             transaction_version = txn_version,
                             index = index,
                                 error = ?e,
                             "[Parser] error parsing fungible balance v2");
-                            panic!("[Parser] error parsing fungible balance v2");
+                            anyhow::anyhow!("[Parser] error parsing fungible balance v2")
                         })
+                        .ok()
+                        .flatten()
                     {
                         fungible_asset_balances.push(balance);
                         current_fungible_asset_balances

--- a/rust/processor/src/processors/nft_metadata_processor.rs
+++ b/rust/processor/src/processors/nft_metadata_processor.rs
@@ -105,10 +105,10 @@ impl ProcessorTrait for NftMetadataProcessor {
         let query_retries = self.config.query_retries;
         let query_retry_delay_ms = self.config.query_retry_delay_ms;
 
-        let db_chain_id = db_chain_id.unwrap_or_else(|| {
+        let db_chain_id = db_chain_id.ok_or_else(|| {
             error!("[NFT Metadata Crawler] db_chain_id must not be null");
-            panic!();
-        });
+            anyhow::anyhow!("[NFT Metadata Crawler] db_chain_id must not be null")
+        })?;
 
         // First get all token related table metadata from the batch of transactions. This is in case
         // an earlier transaction has metadata (in resources) that's missing from a later transaction.

--- a/rust/processor/src/processors/objects_processor.rs
+++ b/rust/processor/src/processors/objects_processor.rs
@@ -179,16 +179,8 @@ impl ProcessorTrait for ObjectsProcessor {
 
         for txn in &transactions {
             let txn_version = txn.version as i64;
-            let changes = &txn
-                .info
-                .as_ref()
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Transaction info doesn't exist! Transaction {}",
-                        txn_version
-                    )
-                })
-                .changes;
+            let vec = vec![];
+            let changes = &txn.info.as_ref().map(|info| &info.changes).unwrap_or(&vec);
 
             // First pass to get all the object cores
             for wsc in changes.iter() {
@@ -198,24 +190,27 @@ impl ProcessorTrait for ObjectsProcessor {
                         ObjectWithMetadata::from_write_resource(wr, txn_version).unwrap()
                     {
                         // Object core is the first struct that we need to get
-                        object_metadata_helper.insert(address.clone(), ObjectAggregatedData {
-                            object: object_with_metadata,
-                            token: None,
-                            fungible_asset_store: None,
-                            // The following structs are unused in this processor
-                            fungible_asset_metadata: None,
-                            aptos_collection: None,
-                            fixed_supply: None,
-                            unlimited_supply: None,
-                            concurrent_supply: None,
-                            property_map: None,
-                            transfer_events: vec![],
-                            untransferable: None,
-                            fungible_asset_supply: None,
-                            concurrent_fungible_asset_supply: None,
-                            concurrent_fungible_asset_balance: None,
-                            token_identifier: None,
-                        });
+                        object_metadata_helper.insert(
+                            address.clone(),
+                            ObjectAggregatedData {
+                                object: object_with_metadata,
+                                token: None,
+                                fungible_asset_store: None,
+                                // The following structs are unused in this processor
+                                fungible_asset_metadata: None,
+                                aptos_collection: None,
+                                fixed_supply: None,
+                                unlimited_supply: None,
+                                concurrent_supply: None,
+                                property_map: None,
+                                transfer_events: vec![],
+                                untransferable: None,
+                                fungible_asset_supply: None,
+                                concurrent_fungible_asset_supply: None,
+                                concurrent_fungible_asset_balance: None,
+                                token_identifier: None,
+                            },
+                        );
                     }
                 }
             }

--- a/rust/processor/src/processors/parquet_processors/parquet_fungible_asset_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_fungible_asset_processor.rs
@@ -255,14 +255,17 @@ async fn parse_v2_coin(
                         &fungible_asset_object_helper,
                     )
                     .await
-                    .unwrap_or_else(|e| {
+                    .map_err(|e| {
                         tracing::error!(
                             transaction_version = txn_version,
                             index = index,
                                 error = ?e,
                             "[Parser] error parsing fungible balance v2");
-                        panic!("[Parser] error parsing fungible balance v2");
-                    }) {
+                        anyhow::anyhow!("[Parser] error parsing fungible balance v2")
+                    })
+                    .ok()
+                    .flatten()
+                    {
                         fungible_asset_balances.push(balance);
                         transaction_version_to_struct_count
                             .entry(txn_version)

--- a/rust/processor/src/utils/util.rs
+++ b/rust/processor/src/utils/util.rs
@@ -168,17 +168,23 @@ pub fn get_clean_payload(payload: &TransactionPayload, version: i64) -> Option<V
     match payload.payload.as_ref().unwrap() {
         PayloadType::EntryFunctionPayload(inner) => {
             let clean = get_clean_entry_function_payload(inner, version);
-            Some(serde_json::to_value(clean).unwrap_or_else(|_| {
-                tracing::error!(version = version, "Unable to serialize payload into value");
-                panic!()
-            }))
+            serde_json::to_value(clean).map_or_else(
+                |_| {
+                    tracing::error!(version = version, "Unable to serialize payload into value");
+                    None
+                },
+                Some,
+            )
         },
         PayloadType::ScriptPayload(inner) => {
             let clean = get_clean_script_payload(inner, version);
-            Some(serde_json::to_value(clean).unwrap_or_else(|_| {
-                tracing::error!(version = version, "Unable to serialize payload into value");
-                panic!()
-            }))
+            serde_json::to_value(clean).map_or_else(
+                |_| {
+                    tracing::error!(version = version, "Unable to serialize payload into value");
+                    None
+                },
+                Some,
+            )
         },
         PayloadType::WriteSetPayload(inner) => {
             if let Some(writeset) = inner.write_set.as_ref() {
@@ -211,10 +217,13 @@ pub fn get_clean_payload(payload: &TransactionPayload, version: i64) -> Option<V
                     transaction_payload: None,
                 }
             };
-            Some(serde_json::to_value(clean).unwrap_or_else(|_| {
-                tracing::error!(version = version, "Unable to serialize payload into value");
-                panic!()
-            }))
+            serde_json::to_value(clean).map_or_else(
+                |_| {
+                    tracing::error!(version = version, "Unable to serialize payload into value");
+                    None
+                },
+                Some,
+            )
         },
     }
 }
@@ -231,16 +240,12 @@ pub fn get_clean_writeset(writeset: &WriteSet, version: i64) -> Option<Value> {
                 return None;
             }
             let payload = inner.script.as_ref().unwrap();
-            Some(
-                serde_json::to_value(get_clean_script_payload(payload, version)).unwrap_or_else(
-                    |_| {
-                        tracing::error!(
-                            version = version,
-                            "Unable to serialize payload into value"
-                        );
-                        panic!()
-                    },
-                ),
+            serde_json::to_value(get_clean_script_payload(payload, version)).map_or_else(
+                |_| {
+                    tracing::error!(version = version, "Unable to serialize payload into value");
+                    None
+                },
+                Some,
             )
         },
         WriteSetType::DirectWriteSet(_) => None,

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -501,10 +501,7 @@ impl Worker {
                                 "[Parser][T#{}] Stream somehow changed chain id!",
                                 task_index
                             );
-                            panic!(
-                                "[Parser][T#{}] Stream somehow changed chain id!",
-                                task_index
-                            );
+                            break;
                         }
 
                         let processing_time = std::time::Instant::now();


### PR DESCRIPTION
We get an issue with coin processor. A coin parsing failed and panicked, but the processor never stopped, so the opened Postgresql Tx stay open and block the other processor (fungible in our case).

The panic:
```
2025-06-17T11:06:23.695072Z ERROR processor::worker: [Parser][T#6] Error processing transactions processor_name="coin_processor" stream_address="http://54.186.46.77:30734/" error=spawn_blocking for CoinProcessor thread failed
Caused by:
    task 3495 panicked with message "Could not find event in resources (CoinStore), version: 2679605, event guid: EventGuidResource { addr: \"0x0a3677f321b1dcd98bb4c6c739bcbbfbb5e96b3f4205ed2c250577dfa3640f48\", creation_num: 9 }, mapping: {EventGuidResource { addr: \"0x5e52712a09abd215db59f8534a88dc377f5b080c7e5328312bf6aa1ac7e8f533\", creation_num: 3 }: \"0x1::aptos_coin::AptosCoin\", EventGuidResource { addr: \"0x5e52712a09abd215db59f8534a88dc377f5b080c7e5328312bf6aa1ac7e8f533\", creation_num: 2 }: \"0x1::aptos_coin::AptosCoin\"}" task_index=6
```
Remove most of the panic that doesn't create an important change to avoid that a processor panic.