### PR TITLE
chore: downgrade diesel version to 2.2.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe8e2e68695bd615d7e4f3227c0727b151330d3e253b525086c348d055d5e"
+checksum = "35b696af9ff4c0d2a507db2c5faafa8aa0205e297e5f11e203a24226d5355e7a"
 dependencies = [
  "bigdecimal",
  "bitflags 2.5.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,7 +34,7 @@ clap = { version = "4.5", features = ["derive", "unstable-styles"] }
 # Do NOT enable the postgres feature here, it is conditionally enabled in a feature
 # block in the Cargo.toml file for the processor crate.
 # https://github.com/aptos-labs/aptos-indexer-processors/pull/325
-diesel = { version = "2.2.3", features = [
+diesel = { version = "2.2.0", features = [
     "chrono",
     "postgres_backend",
     "numeric",


### PR DESCRIPTION
attempt to fix version mismatch in https://github.com/movementlabsxyz/movement/pull/1264